### PR TITLE
[explore-all] filter out disabled collections

### DIFF
--- a/app.js
+++ b/app.js
@@ -52,6 +52,7 @@ require("./models/turkwork");
 require("./models/sitelock");
 require("./models/paytoken");
 require("./models/unlockable");
+require("./models/disabledExplorerCollection");
 
 app.use(bodyParser.json());
 app.use(express.json());

--- a/models/disabledExplorerCollection.js
+++ b/models/disabledExplorerCollection.js
@@ -1,0 +1,9 @@
+const mongoose = require("mongoose");
+
+const DisabledExplorerCollection = mongoose.Schema({
+  minterAddress: { type: String, required: true, index: { unique: true } },
+  type: { type: Number, default: 721 },
+  reason: { type: String },
+});
+
+mongoose.model("DisabledExplorerCollection", DisabledExplorerCollection);


### PR DESCRIPTION
- Filters out all collections present in the DisabledExplorerCollection table for the explore-all results.
- Disabled explorer collections are only retuned in results when they are specifically selected in the explore-filter.